### PR TITLE
Fixed NullPointerException bug

### DIFF
--- a/src/main/java/at/favre/tools/apksigner/ui/FileArgParser.java
+++ b/src/main/java/at/favre/tools/apksigner/ui/FileArgParser.java
@@ -50,7 +50,13 @@ public class FileArgParser {
             if (file.isDirectory()) {
                 parents.add(file);
             } else {
-                parents.add(file.getParentFile());
+                //Fixed bug: java -jar uber-apk-signer*.jar -a test_unsigned.apk throw NullPointerException
+                try {
+                    file = new File(file.getCanonicalPath());
+                    parents.add(file.getParentFile());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
 


### PR DESCRIPTION
Code will throw NullPointerException as below:
java -jar uber-apk-signer.jar --apks test_unsigned.apk
cause:
new File("test_unsigned.apk").getParentFile() will return null.