### PR TITLE
Use the same page alignment for shared object files

### DIFF
--- a/src/main/java/at/favre/tools/apksigner/SignTool.java
+++ b/src/main/java/at/favre/tools/apksigner/SignTool.java
@@ -240,7 +240,7 @@ public final class SignTool {
             if (executor.isExecutableFound()) {
                 String logMsg = "\t- ";
 
-                CmdUtil.Result zipAlignResult = CmdUtil.runCmd(CmdUtil.concat(executor.getZipAlignExecutable(), new String[]{"-v", ZIPALIGN_ALIGNMENT, targetApkFile.getAbsolutePath(), outFile.getAbsolutePath()}));
+                CmdUtil.Result zipAlignResult = CmdUtil.runCmd(CmdUtil.concat(executor.getZipAlignExecutable(), new String[]{"-p", "-v", ZIPALIGN_ALIGNMENT, targetApkFile.getAbsolutePath(), outFile.getAbsolutePath()}));
                 cmdList.add(zipAlignResult);
                 if (zipAlignResult.success()) {
                     logMsg += "zipalign success";


### PR DESCRIPTION
outfile.zip should use the same page alignment for all shared object files within infile.zip as mentioned in https://developer.android.com/studio/command-line/zipalign.html

Ref: https://stackoverflow.com/a/41263135